### PR TITLE
Disable role sync  on Spinnaker application creation (1.24.x)

### DIFF
--- a/front50-core/src/main/java/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
+++ b/front50-core/src/main/java/com/netflix/spinnaker/front50/ApplicationPermissionsService.java
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.front50.model.application.ApplicationPermissionDAO;
 import com.netflix.spinnaker.kork.exceptions.SystemException;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -182,7 +181,13 @@ public class ApplicationPermissionsService {
 
     if (fiatConfigurationProperties.getRoleSync().isEnabled()) {
       try {
-        fiatService.get().sync(new ArrayList<>(roles));
+        // Note:
+        // Disable triggering fiat permission sync because it make fiat unstable when there are many
+        // roles.
+        // This is a temporary solution until https://github.com/spinnaker/front50/pull/995 gets
+        // merged.
+        log.info("skip fiat permission sync: ApplicationPermissionsService#syncUsers");
+        // fiatService.get().sync(new ArrayList<>(roles));
       } catch (RetrofitError e) {
         log.warn("Error syncing users", e);
       }

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
@@ -130,7 +130,7 @@ public class ApplicationsController {
         // roles.
         // This is a temporary solution until https://github.com/spinnaker/front50/pull/995 gets
         // merged.
-        log.info("skip fiat permission sync: ApplicationPermissionsService#syncAllUsers");
+        log.info("skip fiat permission sync: ApplicationPermissionsService#creat");
         // fiatService.get().sync();
       } catch (Exception e) {
         log.warn("failed to trigger fiat permission sync", e);

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
@@ -130,7 +130,7 @@ public class ApplicationsController {
         // roles.
         // This is a temporary solution until https://github.com/spinnaker/front50/pull/995 gets
         // merged.
-        log.info("skip fiat permission sync: ApplicationPermissionsService#creat");
+        log.info("skip fiat permission sync: ApplicationPermissionsService#create");
         // fiatService.get().sync();
       } catch (Exception e) {
         log.warn("failed to trigger fiat permission sync", e);

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
@@ -130,7 +130,7 @@ public class ApplicationsController {
         // roles.
         // This is a temporary solution until https://github.com/spinnaker/front50/pull/995 gets
         // merged.
-        log.info("skip fiat permission sync: ApplicationPermissionsService#create");
+        log.info("skip fiat permission sync: ApplicationsController#create");
         // fiatService.get().sync();
       } catch (Exception e) {
         log.warn("failed to trigger fiat permission sync", e);

--- a/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
+++ b/front50-web/src/main/java/com/netflix/spinnaker/front50/controllers/v2/ApplicationsController.java
@@ -125,7 +125,13 @@ public class ApplicationsController {
         && fiatConfigurationProperties.getRoleSync().isEnabled()
         && fiatService.isPresent()) {
       try {
-        fiatService.get().sync();
+        // Note:
+        // Disable triggering fiat permission sync because it make fiat unstable when there are many
+        // roles.
+        // This is a temporary solution until https://github.com/spinnaker/front50/pull/995 gets
+        // merged.
+        log.info("skip fiat permission sync: ApplicationPermissionsService#syncAllUsers");
+        // fiatService.get().sync();
       } catch (Exception e) {
         log.warn("failed to trigger fiat permission sync", e);
       }


### PR DESCRIPTION
## WHAT

This pull request disables triggering fiat permission sync for application.
This is for Spinnaker version `1.24.x`.

## WHY

As described in https://github.com/spinnaker/front50/pull/995 , we have some issues around fiat permission sync.
As a workaround, we'd like to disable the fiat permission sync, only all roles sync when creating application because it's very expensive when there are many roles.

## REF

- https://github.com/mercari/front50/pull/1
